### PR TITLE
Update Dockerfile with socat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update -qq \ 
- && apt-get install -qqy apt-transport-https software-properties-common bzip2 libavahi-client3 libav-tools xmltv wget udev gnupg2
+ && apt-get install -qqy apt-transport-https software-properties-common bzip2 libavahi-client3 libav-tools xmltv wget udev gnupg2 socat
 
 # Add key and tvheadend repository
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61


### PR DESCRIPTION
As the xmltv EPG parser accepts files via socat, it would be helpful to have socat included in the dockerfile. I have a script that downloads an EPG each night. currently I need to install socat after every restart to be able to feed TVHE the EPG file.
from my script: 
cat /config/scripts/epg.xml | socat - UNIX-CONNECT:/config/epggrab/xmltv.sock